### PR TITLE
JSON: string enum, PascalCase

### DIFF
--- a/Buildlease/Buildlease/Buildlease.csproj
+++ b/Buildlease/Buildlease/Buildlease.csproj
@@ -11,6 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.11" />
         <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="5.0.11" />
         <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="5.0.11" />
         <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="5.0.11" />

--- a/Buildlease/Buildlease/Startup.cs
+++ b/Buildlease/Buildlease/Startup.cs
@@ -14,6 +14,9 @@ using Domain.Models;
 using Services.Abstractions;
 using Services;
 using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Newtonsoft.Json.Converters;
 
 namespace Buildlease
 {
@@ -44,7 +47,14 @@ namespace Buildlease
             services.AddAuthentication()
                 .AddIdentityServerJwt();
 
-            services.AddControllersWithViews();
+            services.AddControllersWithViews()
+                .AddNewtonsoftJson(options =>
+                {
+                    options.SerializerSettings.Converters.Add(new StringEnumConverter() { NamingStrategy = new DefaultNamingStrategy() });
+                    options.SerializerSettings.ContractResolver = new DefaultContractResolver { NamingStrategy = new DefaultNamingStrategy() };
+                    options.SerializerSettings.Formatting = Formatting.Indented;
+                });
+
             services.AddRazorPages();
 
             // In production, the React files will be served from this directory


### PR DESCRIPTION
Добавлены настройки для улучшения передаваемого `JSON-Response`:
- `enum`-значения теперь передаются в виде строки — на фронте вместо _магических чисел_ будут _магические строки_, что более понятно
- при передаче объектов сохраняются исходные именования полей (в большинстве случаев — **P**ascalCase)