### PR TITLE
Console run now works

### DIFF
--- a/Buildlease/Buildlease/ClientApp/package-lock.json
+++ b/Buildlease/Buildlease/ClientApp/package-lock.json
@@ -5716,13 +5716,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001278",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001278.tgz",
-      "integrity": "sha512-mpF9KeH8u5cMoEmIic/cr7PNS+F5LWBk0t2ekGT60lFf0Wq+n9LspAj0g3P+o7DQhD3sUdlMln4YFAWhFYn9jg==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001340",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001340.tgz",
+      "integrity": "sha512-jUNz+a9blQTQVu4uFcn17uAD8IDizPzQkIKh3LCJfg9BkyIqExYYdyc/ZSlWUSKb8iYiXxKsxbv4zYSvkqjrxw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -26871,9 +26877,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001278",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001278.tgz",
-      "integrity": "sha512-mpF9KeH8u5cMoEmIic/cr7PNS+F5LWBk0t2ekGT60lFf0Wq+n9LspAj0g3P+o7DQhD3sUdlMln4YFAWhFYn9jg=="
+      "version": "1.0.30001340",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001340.tgz",
+      "integrity": "sha512-jUNz+a9blQTQVu4uFcn17uAD8IDizPzQkIKh3LCJfg9BkyIqExYYdyc/ZSlWUSKb8iYiXxKsxbv4zYSvkqjrxw=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/Buildlease/Buildlease/ClientApp/package.json
+++ b/Buildlease/Buildlease/ClientApp/package.json
@@ -39,7 +39,8 @@
     "start": "rimraf ./build && react-scripts start",
     "build": "react-scripts build",
     "test": "cross-env CI=true react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "rimraf": "./node_modules/rimraf/bin.js"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
These changes make it possible for the project to run via console `dotnet run --project Buildlease`. There were issues with dependencies in the client app.

Might not be the best solution bc I just fixed npm errors that popped up without thinking that much about the nature of the changes made.

Might also need to set an env variable (https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported).